### PR TITLE
Corrected compose method to return the  correct output.

### DIFF
--- a/src/main/scala/org/vincibean/scala/impatient/chapter14/exercise10/package.scala
+++ b/src/main/scala/org/vincibean/scala/impatient/chapter14/exercise10/package.scala
@@ -30,10 +30,35 @@ package org.vincibean.scala.impatient.chapter14
   */
 package object exercise10 {
 
-  def compose(f: Double => Option[Double], g: Double => Option[Double]): Double => Option[Double] = d =>
-    (f(d), g(d)) match {
-      case (Some(_), b @ Some(_)) => b
-      case _ => None
+// h(2) returns Some(1), h(1) returns None, but h(0) returns -1.0 instead of None
+//   def compose(f: Double => Option[Double], g: Double => Option[Double]): Double => Option[Double] = d =>
+//     (f(d), g(d)) match {
+//       case (Some(_), b @ Some(_)) => b
+//       case _ => None
+//     }
+ 
+def compose(f: Double => Option[Double], g: Double => Option[Double]): (Double) => Option[Double] = (x: Double) => {
+    g(x) match {
+        case Some(a) => f(a) 
+        case _ => None
     }
+}
+ 
+// Alternate version using the 'val function' syntax to declare a local function and return it. 
+def compose2(f: Double => Option[Double], g: Double => Option[Double]): (Double) => Option[Double] = {
+    // This is the syntax to explicitly declare the return type of a 'val function'.  The full function
+    // type declaration occurs between the : and the =.
+    val h: (Double) => Option[Double] = (x: Double) =>  {
+        g(x) match {
+            case Some(a) => f(a) 
+            case _ => None
+        }
+    }
+    h // return the function 
+}
+
+ 
+ 
+
 
 }


### PR DESCRIPTION
The function h that compose() returns does not compute the correct output for h(0).  I have provided an alternate compose() method that returns the correct output.  

During my initial attempt to write this exercise, I tried to create a 'var function' and return it, but the compiler kept getting confused about the return type and it took some time for me (a beginner) to get the var declaration syntax correct, so I included an alternate with the correct syntax in case it is helpful for another beginner. 